### PR TITLE
Make position params unique

### DIFF
--- a/actions/del_bgp_adv_prefix.yaml
+++ b/actions/del_bgp_adv_prefix.yaml
@@ -15,12 +15,12 @@ parameters:
         type: integer
         description: Local AS number
         required: true
-        position: 0 
+        position: 1
     prefix:
         type: array
         description: list of IP prefix to advertise
         required: true
-        position: 1
+        position: 2
 notify:
   on-complete:
     message: "\"@channel: Action succeeded.\""

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,6 +4,6 @@ description: A StackStorm pack for working with vyatta vRouter
 keywords:
     - networking
     - vyatta
-version: 0.1.0
+version: 0.1.1
 author: Mehdi Abdelouahab 
 email: mabdelou@brocade.com


### PR DESCRIPTION
cc @mab27 

We're going to add a change to future ST2 versions to fail on pack registration if position params are non-unique. From a quick scan, I noticed this one needed tidying up